### PR TITLE
support local dirs as repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ gradle-dot-nix-instance =
     };
 ```
 
+### Custom Local Repositories
+
+If some your dependencies are already available locally, you can set the optional `local-maven-repos` input to an array of store paths.
+This is especially useful for react-native apps, where some maven repos are available through NPM.
+
+```nix 
+gradle-dot-nix-instance = 
+    import gradle-dot-nix {
+        inherit pkgs;
+        gradle-verification-metadata-file = ./gradle/verification-metadata.xml;
+        local-maven-repos = [
+            "${nodeModules}/node_modules/jsc-android/dist"
+        ];
+    };
+```
+
 ### Private Repositories (WIP)
 
 Implementing proper support for private repositories is a bit more complex, as the credentials should not be leaked into the nix store.

--- a/default.nix
+++ b/default.nix
@@ -185,6 +185,12 @@ let
   # it changes the project settings (settings.gradle.kts or settings.gradle) to use our repository
   # i'm not sure if we also need repositoriesMode.set(RepositoriesMode.PREFER_PROJECT), but it surely helps
   gradleInit = pkgs.writeText "init.gradle.kts" ''
+    beforeSettings {
+        System.setProperty(
+          "org.gradle.internal.plugins.portal.url.override",
+          "${gradle-dependency-maven-repo}"
+        )
+    }
     projectsLoaded {
         rootProject.allprojects {
             buildscript {

--- a/default.nix
+++ b/default.nix
@@ -8,10 +8,10 @@
             "https://maven.google.com"
         ]
       '',
-    local-repos ? [ ]
+    local-maven-repos ? [ ]
 }:
 let
-  local-repos-string = pkgs.lib.concatStringsSep " " local-repos;
+  local-repos-string = pkgs.lib.concatStringsSep " " local-maven-repos;
   # we need to convert the gradle metadata to json
   # this json data is completely static and can be used to fetch the dependencies
   gradle-deps-json = pkgs.stdenv.mkDerivation {

--- a/default.nix
+++ b/default.nix
@@ -7,9 +7,11 @@
             "https://plugins.gradle.org/m2",
             "https://maven.google.com"
         ]
-      ''
+      '',
+    local-repos ? [ ]
 }:
 let
+  local-repos-string = pkgs.lib.concatStringsSep " " local-repos;
   # we need to convert the gradle metadata to json
   # this json data is completely static and can be used to fetch the dependencies
   gradle-deps-json = pkgs.stdenv.mkDerivation {
@@ -81,7 +83,12 @@ let
           src = ./.;
           nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.requests ];
           installPhase = ''
-            python3 fetch-gradle-dependency.py $out fetch-module ${public-maven-repos-file} ${unique-dependency.module_file.name} ${unique-dependency.module_file.group} ${unique-dependency.module_file.version} ${unique-dependency.module_file.artifact_name} ${unique-dependency.module_file.artifact_dir} ${unique-dependency.module_file.sha_256}
+            local=$(find ${local-repos-string} -name '${unique-dependency.artifact_name}' -type f -print -quit)
+            if [[ $local ]]; then
+              cp $local $out
+            else
+              python3 fetch-gradle-dependency.py $out fetch-module ${public-maven-repos-file} ${unique-dependency.module_file.name} ${unique-dependency.module_file.group} ${unique-dependency.module_file.version} ${unique-dependency.module_file.artifact_name} ${unique-dependency.module_file.artifact_dir} ${unique-dependency.module_file.sha_256}
+            fi
           '';
           outputHashAlgo = "sha256";
           outputHash = unique-dependency.module_file.sha_256;
@@ -91,7 +98,12 @@ let
           src = ./.;
           nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.requests ];
           installPhase = ''
-            python3 fetch-gradle-dependency.py $out fetch-file ${public-maven-repos-file} ${unique-dependency.name} ${unique-dependency.group} ${unique-dependency.version} ${unique-dependency.artifact_name} ${unique-dependency.artifact_dir} ${unique-dependency.sha_256} ${unique-dependency.module_file.artifact_name}
+            local=$(find ${local-repos-string} -name '${unique-dependency.artifact_name}' -type f -print -quit)
+            if [[ $local ]]; then
+              cp $local $out
+            else
+              python3 fetch-gradle-dependency.py $out fetch-file ${public-maven-repos-file} ${unique-dependency.name} ${unique-dependency.group} ${unique-dependency.version} ${unique-dependency.artifact_name} ${unique-dependency.artifact_dir} ${unique-dependency.sha_256} ${unique-dependency.module_file.artifact_name}
+            fi
           '';
           outputHashAlgo = "sha256";
           outputHash = unique-dependency.sha_256;
@@ -116,7 +128,12 @@ let
           src = ./.;
           nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.requests ];
           installPhase = ''
-            python3 fetch-gradle-dependency.py $out fetch-module ${public-maven-repos-file} ${unique-dependency.name} ${unique-dependency.group} ${unique-dependency.version} ${unique-dependency.artifact_name} ${unique-dependency.artifact_dir} ${unique-dependency.sha_256}
+            local=$(find ${local-repos-string} -name '${unique-dependency.artifact_name}' -type f -print -quit)
+            if [[ $local ]]; then
+              cp $local $out
+            else
+              python3 fetch-gradle-dependency.py $out fetch-module ${public-maven-repos-file} ${unique-dependency.name} ${unique-dependency.group} ${unique-dependency.version} ${unique-dependency.artifact_name} ${unique-dependency.artifact_dir} ${unique-dependency.sha_256}
+            fi
           '';
           outputHashAlgo = "sha256";
           outputHash = unique-dependency.sha_256;


### PR DESCRIPTION
my use case is that, in react native some packages comes from the `node_modules` dir,
as an alternative, the derivation could simply not fail on missing deps,
Gradle should be able to find these by itself (I think)