### PR TITLE
added impureEnvVars to enable usage of NETRC

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@
     local-maven-repos ? [ ]
 }:
 let
+  impureEnvVars = pkgs.lib.fetchers.proxyImpureEnvVars ++ [ "NETRC" "netrc" ];
   local-repos-string = pkgs.lib.concatStringsSep " " local-maven-repos;
   # we need to convert the gradle metadata to json
   # this json data is completely static and can be used to fetch the dependencies
@@ -69,6 +70,7 @@ let
       pkgs.stdenv.mkDerivation {
         name = unique-dependency.artifact_name;
         src = ./.;
+        inherit impureEnvVars;
         INTERNAL_PATH = unique-dependency.artifact_dir + "/" + unique-dependency.artifact_name;
         installPhase = ''
           directory=$out/$(dirname "$INTERNAL_PATH")
@@ -82,6 +84,7 @@ let
           name = unique-dependency.module_file.artifact_name;
           src = ./.;
           nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.requests ];
+          inherit impureEnvVars;
           installPhase = ''
             local=$(find ${local-repos-string} -name '${unique-dependency.artifact_name}' -type f -print -quit)
             if [[ $local ]]; then
@@ -97,6 +100,7 @@ let
           name = unique-dependency.artifact_name;
           src = ./.;
           nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.requests ];
+          inherit impureEnvVars;
           installPhase = ''
             local=$(find ${local-repos-string} -name '${unique-dependency.artifact_name}' -type f -print -quit)
             if [[ $local ]]; then
@@ -113,6 +117,7 @@ let
         name = unique-dependency.artifact_name;
         src = ./.;
         nativeBuildInputs = [ pkgs.python3 ];
+        inherit impureEnvVars;
         installPhase = ''
           INTERNAL_PATH=`python3 rename-module.py ${module-derivation} ${unique-dependency.artifact_name} ${unique-dependency.artifact_dir}`
           directory=$out/$(dirname "$INTERNAL_PATH")
@@ -127,6 +132,7 @@ let
           name = unique-dependency.artifact_name;
           src = ./.;
           nativeBuildInputs = [ pkgs.python3 pkgs.python3Packages.requests ];
+          inherit impureEnvVars;
           installPhase = ''
             local=$(find ${local-repos-string} -name '${unique-dependency.artifact_name}' -type f -print -quit)
             if [[ $local ]]; then
@@ -143,6 +149,7 @@ let
         name = unique-dependency.artifact_name;
         src = ./.;
         INTERNAL_PATH = unique-dependency.artifact_dir + "/" + unique-dependency.artifact_name;
+        inherit impureEnvVars;
         installPhase = ''
           directory=$out/$(dirname "$INTERNAL_PATH")
           mkdir -p $directory


### PR DESCRIPTION
Hi,

with help of people at NixCon (shoutout to @tilpner and  @aforemny, you helped me out big time 😸), I managed to enable usage of netrc as discussed [here](https://github.com/CrazyChaoz/gradle-dot-nix/issues/1#issuecomment-2420662810) regarding the [issue of using private repositories](https://github.com/CrazyChaoz/gradle-dot-nix/issues/1). This does therefore solve the issue altogether afaik.

Essentially gradle-dot-nix must only enable usage of the corresponding impure environment variables. As a downstream user of gradle-dot-nix, I must make sure to configure the correct impureEnv (for example using the from nix 2.19 supported `configurable-impure-env`-experimental feature, which does enable configuration of the `impure-env` property in `nix.conf`). 

See for details about that [here](https://nix.dev/manual/nix/2.19/command-ref/conf-file.html#conf-impure-env). 
Even before 2.19, there are options to do that, for example by providing the environment variable to the `nix-daemon`. 

Additionally as a downstream user, I must of course provide the location of the netrc file into the sandbox (see `extra-sandbox-paths`, available at a couple of places, depending on the case).

Additionally to the `NETRC` passthrough, I added the proxy environment variables to enable sufficient corporate configuration. 


Please let me know, what you think!

Best regards
Dean